### PR TITLE
Fix NAT gateway configuration by changing 'vpc' to 'domain'

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -173,7 +173,7 @@ resource "aws_egress_only_internet_gateway" "this" {
 resource "aws_eip" "nat" {
   count = local.create_vpc && var.enable_nat_gateway && false == var.reuse_nat_ips ? local.nat_gateway_count : 0
 
-  vpc = true
+  domain = true
 
   tags = merge(
     {


### PR DESCRIPTION
This pull request includes a change to the `main.tf` file to correct a configuration attribute for the AWS Elastic IP resource. The change involves modifying the `vpc` attribute to `domain` to ensure proper configuration as it was showing deprecated.

Configuration correction:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL176-R176): Changed the attribute `vpc` to `domain` in the `aws_eip` resource block to correct the configuration.

![image](https://github.com/user-attachments/assets/1de7975d-19e4-47c1-8195-b4b164fb9994)
