### PR TITLE
Change NAT gateway EIP domain from true to "vpc"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -173,7 +173,7 @@ resource "aws_egress_only_internet_gateway" "this" {
 resource "aws_eip" "nat" {
   count = local.create_vpc && var.enable_nat_gateway && false == var.reuse_nat_ips ? local.nat_gateway_count : 0
 
-  domain = true
+  domain = "vpc"
 
   tags = merge(
     {


### PR DESCRIPTION
This pull request includes a small change to the `main.tf` file. The change updates the `domain` attribute of the `aws_eip` resource from a boolean value to a string value as the bool which I requested merge last time was solving the deprecated prob but causing conflict in implementation. I have tested the string domain `"vpc"` and it is working as expected on aws without showing conflict.

![image](https://github.com/user-attachments/assets/e49eb9e7-f1f7-455f-be82-e1ec0b9455ed)

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL176-R176): Modified the `domain` attribute in the `aws_eip` resource to use the string "vpc" instead of the boolean value `true`.

**Error Message:**

![image](https://github.com/user-attachments/assets/dcbff77e-9213-423d-8100-6389e1293a17)
